### PR TITLE
Commented out delete_method import to allow first example GET request to work

### DIFF
--- a/run_app.py
+++ b/run_app.py
@@ -3,7 +3,7 @@ import os
 from api._01_manual_response_class import app
 # from api._02_make_response_helper import app
 # from api._03_post_method import app
-from api._04_delete_method import app
+# from api._04_delete_method import app
 # from api._05_flask_restful_simple import app
 
 


### PR DESCRIPTION
When following the first example, the GET request was returning "OperationalError: no such table: book".  The problem seemed to be a g.db.execute command in _04_delete_method.py.  I commented out the import for _04_delete_method import app in run_app.py and the GET request proceeded to work fine.